### PR TITLE
fix: probe arm64/x86_64 JRE paths on macOS

### DIFF
--- a/src/server/paths.ts
+++ b/src/server/paths.ts
@@ -203,7 +203,10 @@ function findInstallRoot(): { installRoot: string; probed: ProbedPath[] } {
     throw new ShamelaNotFoundError(probed);
 }
 
-function resolveJre(installRoot: string): string {
+export function resolveJre(
+    installRoot: string,
+    platform: NodeJS.Platform = process.platform,
+): string {
     const envJre = process.env.SHAMELA_JRE?.trim();
     if (envJre) {
         // Accept either a directory or the executable itself.
@@ -221,15 +224,21 @@ function resolveJre(installRoot: string): string {
         throw new Error(`SHAMELA_JRE = ${envJre} لا يُشير إلى ملف جافا تنفيذي صالح.`);
     }
 
-    const isWin = process.platform === "win32";
     const candidates: string[] = [];
-    if (isWin) {
+    if (platform === "win32") {
         candidates.push(
             path.join(installRoot, "app", "win", "64", "jre", "2", "bin", "java.exe"),
             path.join(installRoot, "app", "win", "32", "jre", "2", "bin", "java.exe"),
         );
-    } else if (process.platform === "darwin") {
-        candidates.push(path.join(installRoot, "app", "mac", "64", "jre", "2", "bin", "java"));
+    } else if (platform === "darwin") {
+        // Mac Shamela ships the bundled JRE under the CPU architecture name
+        // (arm64 on Apple Silicon, x86_64 on Intel), not the Windows-style
+        // 32/64 split. Probe the legacy "64" path last for any older install.
+        candidates.push(
+            path.join(installRoot, "app", "mac", "arm64", "jre", "2", "bin", "java"),
+            path.join(installRoot, "app", "mac", "x86_64", "jre", "2", "bin", "java"),
+            path.join(installRoot, "app", "mac", "64", "jre", "2", "bin", "java"),
+        );
     } else {
         candidates.push(path.join(installRoot, "app", "linux", "64", "jre", "2", "bin", "java"));
     }
@@ -237,6 +246,7 @@ function resolveJre(installRoot: string): string {
     for (const c of candidates) if (fs.existsSync(c)) return c;
     throw new Error(
         `تعذَّر إيجاد جافا المرفقة مع المكتبة الشاملة في ${path.join(installRoot, "app")}. ` +
+            `بُحث في: ${candidates.join(", ")}. ` +
             `اضبط متغيِّر SHAMELA_JRE ليُشير إلى ملف جافا تنفيذي (إعداد متقدم).`,
     );
 }

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { resolveJre } from "../../src/server/paths.js";
+
+function makeJavaStub(dir: string): string {
+    fs.mkdirSync(dir, { recursive: true });
+    const javaPath = path.join(dir, "java");
+    fs.writeFileSync(javaPath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    return javaPath;
+}
+
+describe("resolveJre — macOS bundled JRE discovery", () => {
+    let tmpRoot: string;
+    let savedEnvJre: string | undefined;
+
+    beforeEach(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shamela-paths-"));
+        savedEnvJre = process.env.SHAMELA_JRE;
+        delete process.env.SHAMELA_JRE;
+    });
+
+    afterEach(() => {
+        if (savedEnvJre === undefined) delete process.env.SHAMELA_JRE;
+        else process.env.SHAMELA_JRE = savedEnvJre;
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it("finds the JRE under app/mac/arm64 on Apple Silicon installs", () => {
+        const expected = makeJavaStub(
+            path.join(tmpRoot, "app", "mac", "arm64", "jre", "2", "bin"),
+        );
+        expect(resolveJre(tmpRoot, "darwin")).toBe(expected);
+    });
+
+    it("finds the JRE under app/mac/x86_64 on Intel Mac installs", () => {
+        const expected = makeJavaStub(
+            path.join(tmpRoot, "app", "mac", "x86_64", "jre", "2", "bin"),
+        );
+        expect(resolveJre(tmpRoot, "darwin")).toBe(expected);
+    });
+
+    it("still finds the JRE under the legacy app/mac/64 path", () => {
+        const expected = makeJavaStub(
+            path.join(tmpRoot, "app", "mac", "64", "jre", "2", "bin"),
+        );
+        expect(resolveJre(tmpRoot, "darwin")).toBe(expected);
+    });
+
+    it("prefers arm64 when both arm64 and x86_64 are present", () => {
+        const arm = makeJavaStub(
+            path.join(tmpRoot, "app", "mac", "arm64", "jre", "2", "bin"),
+        );
+        makeJavaStub(path.join(tmpRoot, "app", "mac", "x86_64", "jre", "2", "bin"));
+        expect(resolveJre(tmpRoot, "darwin")).toBe(arm);
+    });
+
+    it("throws and lists every probed path when no JRE is found", () => {
+        expect(() => resolveJre(tmpRoot, "darwin")).toThrow(/arm64.*x86_64.*64/s);
+    });
+
+    it("honours SHAMELA_JRE when set, even if a bundled JRE exists", () => {
+        makeJavaStub(path.join(tmpRoot, "app", "mac", "arm64", "jre", "2", "bin"));
+        const overrideDir = fs.mkdtempSync(path.join(os.tmpdir(), "shamela-override-"));
+        try {
+            const override = makeJavaStub(overrideDir);
+            process.env.SHAMELA_JRE = override;
+            expect(resolveJre(tmpRoot, "darwin")).toBe(override);
+        } finally {
+            fs.rmSync(overrideDir, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

On macOS, Shamela installs its bundled JRE under the CPU architecture name (`app/mac/arm64/jre/2/bin/java` on Apple Silicon, `app/mac/x86_64/jre/2/bin/java` on Intel), not `app/mac/64/` as the Windows-style 32/64 split assumed. The current code in `src/server/paths.ts:232` only probes `app/mac/64/`, so the MCP fails to find Java on every Mac install.

## Repro

On an Apple Silicon Mac with Shamela installed at `~/Library/Application Support/Shamela`:

```
ls "$HOME/Library/Application Support/Shamela/app/mac/arm64/jre/2/bin/java"   # exists
ls "$HOME/Library/Application Support/Shamela/app/mac/64/jre/2/bin/java"      # does NOT exist
```

Installing the `.mcpb` in Claude Desktop then surfaces:

> Could not find Java bundled with Al-Maktaba Al-Shamela in /Users/&lt;user&gt;/Library/Application Support/Shamela/app. Set the SHAMELA_JRE environment variable to point to a Java executable (advanced setting).

## Fix

`resolveJre` now probes, on macOS:

1. `app/mac/arm64/jre/2/bin/java` (Apple Silicon)
2. `app/mac/x86_64/jre/2/bin/java` (Intel)
3. `app/mac/64/jre/2/bin/java` (legacy, kept for back-compat)

The error message now lists every probed path so future broken installs are easier to diagnose.

To make `resolveJre` unit-testable, it gains an optional `platform` parameter that defaults to `process.platform` — zero behavior change at runtime — and is exported.

## Tests

Adds `tests/unit/paths.test.ts` (6 cases):

- finds JRE under `app/mac/arm64/...`
- finds JRE under `app/mac/x86_64/...`
- still finds JRE under legacy `app/mac/64/...`
- prefers `arm64` when both `arm64` and `x86_64` exist
- throws and lists every probed path when no JRE is found
- honours `SHAMELA_JRE` even when a bundled JRE exists

The `arm64` and `x86_64` cases fail on `main` without the `paths.ts` change.

```
npm run test:unit     # 132 passed (126 prior + 6 new)
```

(Integration tests in `tests/integration/pages.test.ts` need the canonical fixture book 9942 to be downloaded locally per the CLAUDE.md rules — environment-only, unrelated to this fix.)

## Workaround for users on older versions

Until this ships, Mac users hitting the error can unblock themselves via Claude Desktop's extension settings → **مسار جافا (إعداد متقدم)** → set to:

```
/Users/<user>/Library/Application Support/Shamela/app/mac/arm64/jre/2/bin/java
```

(`x86_64` for Intel.) This routes through the existing `SHAMELA_JRE` env-var path in `resolveJre`, which is unchanged.

## Related

- #2 — docs-only PR that documents the workaround above in `README.md` §٨ for users on v1.0.0. The two PRs are independent and either can land first. If this PR (#1) lands first, the README entry added by #2 becomes obsolete and should be dropped before merging #2; if #2 lands first, Mac users have a documented unblock until this fix ships.

## Test plan

- [x] `npm run test:unit` — all 132 unit tests pass
- [x] New 6 tests fail on `main` without the `paths.ts` fix (proper regression test)
- [x] Verified working end-to-end on an Apple Silicon Mac via the env-var workaround prior to the code fix