### PR TITLE
docs(landing): remove personal name credit (maintainer request)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -250,8 +250,8 @@
       <div class="mv"><span class="lat">1.2.0</span> <span class="ar">— يوليو ٢٠٢٦</span><span class="en">— Jul 2026</span></div></div>
     <div class="mi"><div class="mk"><span class="ar">الترخيص</span><span class="en">License</span></div>
       <div class="mv"><span class="ar">مفتوح المصدر · مجّاني</span><span class="en">Open source · free</span></div></div>
-    <div class="mi"><div class="mk"><span class="ar">صاحب المشروع</span><span class="en">Owner</span></div>
-      <div class="mv"><span class="ar">حمود الحقباني</span><span class="en">Hamoud Al-Hoqbani</span></div></div>
+    <div class="mi"><div class="mk"><span class="ar">التوافق</span><span class="en">Requires</span></div>
+      <div class="mv"><span class="ar">المكتبة الشاملة ٤</span><span class="en">Shamela 4 app</span></div></div>
   </div>
 </div>
 
@@ -358,8 +358,8 @@
   <div class="wrap">
     <div class="fgrid">
       <div class="fowner">
-        <span class="ar">صاحب المشروع: <b>حمود الحقباني</b> — محاضر بجامعة الملك عبدالعزيز</span>
-        <span class="en">Project owner: <b>Hamoud Al-Hoqbani</b> — lecturer at King Abdulaziz University</span>
+        <span class="ar">مشروع مفتوح المصدر · للتفاصيل والمساهمة على <b>GitHub</b></span>
+        <span class="en">An open-source project · details &amp; contributions on <b>GitHub</b></span>
       </div>
       <div class="flinks">
         <a href="https://github.com/alhoqbani/shamela-mcp" target="_blank" rel="noopener">GitHub</a>


### PR DESCRIPTION
At the maintainer's request, removes the personal-name credit from the landing page (he is already credited on the repository). The Owner metadata field becomes a Requirements field, and the footer credit becomes a generic open-source note. GitHub links unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)