### PR TITLE
docs: point the README and landing page at shamela.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<sub>الآن يمكنك الاتصال بالمكتبة الشاملة عن بُعد، دون تثبيت تطبيق الشاملة على جهازك — [shamela.link](https://shamela.link)</sub>  
+<sub>You can now connect to Shamela remotely, without a local Shamela app — [shamela.link](https://shamela.link)</sub>  
+<sub>صفحة المشروع · project page — [alhoqbani.github.io/shamela-mcp](https://alhoqbani.github.io/shamela-mcp/)</sub>
+
 # بحث ودراسة في المكتبة الشاملة (إضافة لتطبيق كلود)
 
 إصدار **١٫٣٫٠** — أداة بحث ودراسة عميقة لتطبيق كلود تتيح الوصول الكامل إلى **المكتبة الشاملة ٤** المُثبَّتة على جهازك (المكتبة الإسلامية).

--- a/docs/index.html
+++ b/docs/index.html
@@ -438,9 +438,24 @@
        footer credit's included. */
     .btn::after,.navlinks a::after{content:"" !important}
   }
+  /* remote-server banner — one quiet strip above the header, pointing at shamela.link */
+  .promo{display:flex;justify-content:center;align-items:center;gap:8px;flex-wrap:wrap;
+    background:var(--surface2);border-bottom:1px solid var(--border);color:var(--muted);
+    text-decoration:none;font-size:13.5px;font-weight:500;padding:7px 18px;text-align:center}
+  .promo:hover{color:var(--ink)}
+  .promo .tag{color:var(--coral-deep);font-weight:700;flex-shrink:0}
+  .promo .tag::after{content:"·";margin-inline-start:8px;color:var(--border)}
+  .promo .url{color:var(--coral-deep);text-decoration:underline;text-decoration-thickness:1px;
+    text-underline-offset:3px;white-space:nowrap}
 </style>
 </head>
 <body>
+
+<a class="promo" href="https://shamela.link" target="_blank" rel="noopener">
+  <span class="tag"><span class="ar">جديد</span><span class="en">New</span><span class="fa">جدید</span><span class="sw">Mpya</span><span class="tr">Yeni</span><span class="ru">Новое</span><span class="zh">新</span><span class="ur">نیا</span><span class="fr">Nouveau</span><span class="bn">নতুন</span><span class="id">Baru</span><span class="ms">Baharu</span></span>
+  <span class="ar">يمكنك الآن الاتصال بالمكتبة الشاملة عن بُعد دون تثبيت تطبيق الشاملة على جهازك.</span><span class="en">You can now connect to Shamela remotely, without a local Shamela app.</span><span class="fa">اکنون می‌توانید بدون نصب برنامهٔ الشامله روی دستگاه، از راه دور به آن متصل شوید.</span><span class="sw">Sasa unaweza kuunganisha na Shamela kwa mbali, bila programu ya Shamela kwenye kifaa chako.</span><span class="tr">Artık eş-Şâmile’ye uzaktan bağlanabilirsiniz; cihazınızda uygulamaya gerek yok.</span><span class="ru">Теперь можно подключиться к «аш-Шамиля» удалённо, без установки приложения.</span><span class="zh">现在无需在本机安装谢米莱应用，即可远程连接。</span><span class="ur">اب آپ اپنے آلے پر شاملہ ایپ کے بغیر المکتبۃ الشاملہ سے دور سے منسلک ہو سکتے ہیں۔</span><span class="fr">Vous pouvez désormais vous connecter à Shamela à distance, sans l’application installée.</span><span class="bn">এখন ডিভাইসে শামিলা অ্যাপ ছাড়াই দূর থেকে শামিলার সাথে সংযোগ করা যায়।</span><span class="id">Kini Anda dapat terhubung ke Syamilah dari jarak jauh, tanpa aplikasi Syamilah di perangkat.</span><span class="ms">Kini anda boleh menyambung ke Syamilah dari jauh, tanpa aplikasi Syamilah pada peranti.</span>
+  <span class="url lat">shamela.link</span>
+</a>
 
 <header>
   <div class="wrap nav">


### PR DESCRIPTION
The remote server had no presence in the repo, and the landing page was
unreachable from GitHub — Pages serves `main /docs`, but About → Website was
empty and no README link pointed at it.

- **README** — three subtle `<sub>` lines above the H1: the remote server in
  Arabic and in English, then the project page.
- **Landing page** — one quiet strip above the sticky header, on `--surface2`
  with muted text rather than a coral bar. Translated into all twelve
  languages the page speaks and wired to the same `data-lang` switching, so it
  does not stay Arabic for an English reader.
- **About → Website** set to https://alhoqbani.github.io/shamela-mcp/ (a repo
  setting, already applied — not part of this diff).

Docs only; no shipped code touched.

https://claude.ai/code/session_01J1mTyAgyf4fhkp3nGrMGmW